### PR TITLE
Fix(theme): 글로벌 테마 적용

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -8,6 +8,7 @@ import { Notifications } from "@mantine/notifications";
 import { AuthProvider } from "@/components/common/AuthProvider/AuthProvider";
 import { ReactNode } from "react";
 import { SWRProvider } from "@/api/SWR/SWRProvider";
+import { AppTheme } from "@/theme";
 
 interface Props {
   children: ReactNode;
@@ -21,7 +22,7 @@ export default function RootLayout({ children }: Props) {
       </head>
       <body>
         <SWRProvider>
-          <MantineProvider>
+          <MantineProvider theme={AppTheme}>
             <AuthProvider>
               <Notifications />
               <AppShell>{children}</AppShell>

--- a/src/theme/index.ts
+++ b/src/theme/index.ts
@@ -1,3 +1,5 @@
+"use client";
+
 import { MantineTheme, createTheme } from "@mantine/core";
 import { Interpolation } from "@emotion/react";
 import { Pretendard } from "./typography/fonts";


### PR DESCRIPTION
작성자: @lhwdev

## 작업 내역

- 초기에 <MantineProvider>에 theme={...}을 제공해줘야 하는데 누락되었습니다.

## 비고

- theme/index.ts에 "use client"는 필요합니다. Next.js Server Components에서는 context 관련 api 사용이 제한됩니다.