### PR TITLE
FileUploadRow에 previousFile prop 추가

### DIFF
--- a/src/api/_types/reviews.ts
+++ b/src/api/_types/reviews.ts
@@ -64,7 +64,7 @@ export interface UpdateReviewRequestBody {
   contentStatus: Status;
   presentationStatus?: Status | null;
   comment: string;
-  fileUUID: string;
+  fileUUID?: string;
 }
 
 export interface DetailedRevision extends Review {

--- a/src/components/pages/review/Review/FinalReview.tsx
+++ b/src/components/pages/review/Review/FinalReview.tsx
@@ -11,17 +11,19 @@ import {
 } from "@/components/common/rows";
 import { IconCheck } from "@tabler/icons-react";
 import { Status } from "@/api/_types/common";
+import { File as ApiFile } from "@/api/_types/file";
 
 export interface FinalReviewProps {
   form: UseFormReturnType<{
     status: Status;
     comment: string;
-    commentFile: File | null;
+    commentFile: File | null | undefined;
   }>;
+  previousCommentFile: ApiFile | undefined;
   currentState: null | "pending" | "submitted";
 }
 
-export function FinalReview({ form, currentState }: FinalReviewProps) {
+export function FinalReview({ form, previousCommentFile, currentState }: FinalReviewProps) {
   const { status } = form.values;
   const hasPending = status === "PENDING";
 
@@ -65,7 +67,12 @@ export function FinalReview({ form, currentState }: FinalReviewProps) {
       </RowGroup>
       <TextAreaRow field="심사 의견" form={form} formKey="comment" />
       <RowGroup>
-        <FileUploadRow field="심사 의견 파일" form={form} formKey="commentFile" />
+        <FileUploadRow
+          field="심사 의견 파일"
+          form={form}
+          previousFile={previousCommentFile}
+          formKey="commentFile"
+        />
       </RowGroup>
       <RowGroup withBorderBottom={false}>
         <ButtonRow

--- a/src/components/pages/review/Review/ProfessorReview.tsx
+++ b/src/components/pages/review/Review/ProfessorReview.tsx
@@ -11,6 +11,7 @@ import {
   TitleRow,
 } from "@/components/common/rows";
 import { Status } from "@/api/_types/common";
+import { File as ApiFile } from "@/api/_types/file";
 import { Stage } from "../ThesisInfo/ThesisInfo";
 
 export interface ProfessorReviewProps {
@@ -19,12 +20,18 @@ export interface ProfessorReviewProps {
     thesis: Status;
     presentation: Status | null;
     comment: string;
-    commentFile: File | null;
+    commentFile: File | undefined | null;
   }>;
+  previousCommentFile: ApiFile | undefined;
   currentState: null | "pending" | "submitted";
 }
 
-export function ProfessorReview({ stage, form, currentState }: ProfessorReviewProps) {
+export function ProfessorReview({
+  stage,
+  form,
+  previousCommentFile,
+  currentState,
+}: ProfessorReviewProps) {
   const { thesis, presentation } = form.values;
   const hasPending = thesis === "PENDING" || presentation === "PENDING";
 
@@ -105,7 +112,12 @@ export function ProfessorReview({ stage, form, currentState }: ProfessorReviewPr
       )}
       <TextAreaRow field="심사 의견" form={form} formKey="comment" />
       <RowGroup>
-        <FileUploadRow field="심사 의견 파일" form={form} formKey="commentFile" />
+        <FileUploadRow
+          field="심사 의견 파일"
+          form={form}
+          previousFile={previousCommentFile}
+          formKey="commentFile"
+        />
       </RowGroup>
       <RowGroup withBorderBottom={false}>
         <ButtonRow


### PR DESCRIPTION
작성자: @lhwdev

## 작업 내역

- 기존 FileUploadRow의 생김새가 마음에 들지 않기도 했고, 이 기능이 필요하다고 하셔서 바꿔봤습니다.

## 비고

- 기존에는 form, formKey만 주면 모든 상태를 다 줄 수 있도록 api를 설계했기에, 이렇게 되면 previousFile을 별개로 줘야 하는 불편함이 있습니다. 이건... mantine의 form api가 좀 그렇게 생겨서...
