### PR TITLE
논문 제출 / 수정사항 제출시 성공 페이지로 넘어가도록 구현

### DIFF
--- a/src/app/student/revision/success/page.tsx
+++ b/src/app/student/revision/success/page.tsx
@@ -1,0 +1,17 @@
+import { AuthSSR } from "@/api/AuthSSR";
+import PageHeader from "@/components/common/PageHeader";
+import { Section } from "@/components/common/Section";
+import { SuccessAlert } from "@/components/common/SuccessAlert";
+
+export default async function RevisionSuccessAlertPage() {
+  await AuthSSR({ userType: "STUDENT" });
+
+  return (
+    <>
+      <PageHeader title="수정사항 제출" />
+      <Section>
+        <SuccessAlert message="수정사항이 성공적으로 제출되었습니다." />
+      </Section>
+    </>
+  );
+}

--- a/src/app/student/write/success/page.tsx
+++ b/src/app/student/write/success/page.tsx
@@ -1,0 +1,17 @@
+import { AuthSSR } from "@/api/AuthSSR";
+import PageHeader from "@/components/common/PageHeader";
+import { Section } from "@/components/common/Section";
+import { SuccessAlert } from "@/components/common/SuccessAlert";
+
+export default async function WriteSuccessAlertPage() {
+  await AuthSSR({ userType: "STUDENT" });
+
+  return (
+    <>
+      <PageHeader title="논문 투고" />
+      <Section>
+        <SuccessAlert message="논문이 성공적으로 투고되었습니다." />
+      </Section>
+    </>
+  );
+}

--- a/src/components/common/SuccessAlert/SuccessAlert.module.css
+++ b/src/components/common/SuccessAlert/SuccessAlert.module.css
@@ -1,0 +1,6 @@
+.successIcon {
+  color: var(--mantine-color-blue-6);
+  border: 4px solid var(--mantine-color-blue-6);
+  border-radius: 50%;
+  padding: 10px;
+}

--- a/src/components/common/SuccessAlert/SuccessAlert.tsx
+++ b/src/components/common/SuccessAlert/SuccessAlert.tsx
@@ -1,0 +1,43 @@
+"use client";
+
+import { Button, Stack, Text } from "@mantine/core";
+import { IconCheck } from "@tabler/icons-react";
+import { useRouter } from "next/navigation";
+import classes from "./SuccessAlert.module.css";
+
+interface Props {
+  message: string;
+  subMessage?: string;
+}
+
+function SuccessAlert({ message, subMessage }: Props) {
+  const router = useRouter();
+
+  return (
+    <Stack justify="center" align="center" gap={30} m={60}>
+      <IconCheck size={100} className={classes.successIcon} />
+      <Stack gap={10} align="center">
+        <Text size="xl" fw="bold" fz={28}>
+          {message}
+        </Text>{" "}
+        {subMessage && (
+          <Text size="sm" c="gray" fz={20}>
+            {subMessage}
+          </Text>
+        )}
+      </Stack>
+      <Button
+        color="blue"
+        size="md"
+        radius="md"
+        onClick={() => {
+          router.back();
+        }}
+      >
+        이전 페이지로
+      </Button>
+    </Stack>
+  );
+}
+
+export default SuccessAlert;

--- a/src/components/common/SuccessAlert/index.ts
+++ b/src/components/common/SuccessAlert/index.ts
@@ -1,0 +1,1 @@
+export { default as SuccessAlert } from "@/components/common/SuccessAlert/SuccessAlert";

--- a/src/components/pages/revision/RevisionSubmissionForm/RevisionSubmissionForm.tsx
+++ b/src/components/pages/revision/RevisionSubmissionForm/RevisionSubmissionForm.tsx
@@ -11,6 +11,7 @@ import { Button, Stack } from "@mantine/core";
 import { isNotEmpty, useForm } from "@mantine/form";
 import { useAuth } from "@/components/common/AuthProvider";
 import { useState } from "react";
+import { useRouter } from "next/navigation";
 import classes from "@/components/pages/revision/RevisionSubmissionForm/RevisionSubmissionForm.module.css";
 import useThesis from "@/api/SWR/useThesis";
 import { uploadFile } from "@/api/_utils/uploadFile";
@@ -39,6 +40,7 @@ function RevisionSubmissionForm() {
   });
   const { onSubmit } = form;
   const [isSubmitting, setIsSubmitting] = useState(false);
+  const router = useRouter();
 
   const handleSubmit = async (values: RevisionSubmissionFormInputs) => {
     setIsSubmitting(true);
@@ -46,7 +48,7 @@ function RevisionSubmissionForm() {
       await transaction(async () => {
         const thesisFileUUID = (await uploadFile(values.thesisFile!)).uuid;
         const revisionReportFileUUID = (await uploadFile(values.revisionReportFile!)).uuid;
-        ClientAxios.put(API_ROUTES.student.putThesis(user!.id), {
+        await ClientAxios.put(API_ROUTES.student.putThesis(user!.id), {
           thesisFileUUID,
           revisionReportFileUUID,
         });
@@ -55,6 +57,7 @@ function RevisionSubmissionForm() {
         title: "수정사항 제출 완료",
         message: "수정사항이 제출되었습니다.",
       });
+      router.push("/student/revision/success");
     } catch (error) {
       // TODO: Notification & 에러 처리
     } finally {

--- a/src/components/pages/write/PaperSubmissionForm/PaperSubmissionForm.tsx
+++ b/src/components/pages/write/PaperSubmissionForm/PaperSubmissionForm.tsx
@@ -5,6 +5,7 @@ import { Button, Stack, TextInput } from "@mantine/core";
 import { isNotEmpty, useForm } from "@mantine/form";
 import { useAuth } from "@/components/common/AuthProvider";
 import { uploadFile } from "@/api/_utils/uploadFile";
+import { useRouter } from "next/navigation";
 import { ClientAxios } from "@/api/ClientAxios";
 import { API_ROUTES } from "@/api/apiRoute";
 import { useEffect, useState } from "react";
@@ -39,6 +40,7 @@ function PaperSubmissionForm() {
   });
   const { onSubmit, getInputProps } = form;
   const [isSubmitting, setIsSubmitting] = useState(false);
+  const router = useRouter();
 
   useEffect(() => {
     if (!isLoading) {
@@ -67,6 +69,7 @@ function PaperSubmissionForm() {
         title: "논문 투고 완료",
         message: "논문이 성공적으로 투고되었습니다.",
       });
+      router.push("/student/write/success");
     } catch (error) {
       // TODO: Notification & 에러 처리
     } finally {


### PR DESCRIPTION
작성자: @BestSanghyeon 

## 체크 리스트

- [x] 적절한 제목으로 수정했나요?
- [ ] 상단에 이슈 번호를 기입했나요?
- [x] Target Branch를 올바르게 설정했나요?
- [x] Label을 알맞게 설정했나요?

## 작업 내역

![image](https://github.com/SystemConsultantGroup/real-ice-gs-thesis-frontend/assets/30864861/4db70f00-b553-44e7-a459-17f98b390848)

## 비고

유사한 페이지에서도 사용할 수 있도록 공통 컴포넌트로 구현하였습니다.

사용예)
```tsx
export default async function WriteSuccessAlertPage() {
  await AuthSSR({ userType: "STUDENT" });

  return (
    <>
      <PageHeader title="논문 투고" />
      <Section>
        <SuccessAlert message="논문이 성공적으로 투고되었습니다." />
      </Section>
    </>
  );
}
```

필요시 subMessage 속성도 추가할 수 있습니다.