### PR TITLE
수정페이지에서 학과 정보 default로 뜨도록 수정

### DIFF
--- a/src/components/pages/AdminProfForm/AdminProfForm.tsx
+++ b/src/components/pages/AdminProfForm/AdminProfForm.tsx
@@ -29,6 +29,7 @@ function AdminProfForm({ professorId }: Props) {
   const router = useRouter();
   const { login } = useAuth();
   const [isPwEditing, setIsPwEditing] = useState<boolean>(false);
+  const [defaultDepartmentId, setDefaultDepartmentId] = useState<string | null>(null);
 
   const { onSubmit, getInputProps, setValues, isDirty, setFieldValue } =
     useForm<AdminProfFormInputs>({
@@ -69,6 +70,7 @@ function AdminProfForm({ professorId }: Props) {
             phone: professorDetails.phone,
             deptId: String(professorDetails.deptId),
           });
+          setDefaultDepartmentId(String(professorDetails.deptId));
         }
       } catch (err) {
         console.error(err);
@@ -201,6 +203,7 @@ function AdminProfForm({ professorId }: Props) {
                     width: 300,
                   },
                 }}
+                defaultValue={defaultDepartmentId}
               />
             </BasicRow>
           </RowGroup>

--- a/src/components/pages/AdminStudentForm/_sections/BasicInfoSection.tsx
+++ b/src/components/pages/AdminStudentForm/_sections/BasicInfoSection.tsx
@@ -20,6 +20,7 @@ interface Props {
 function BasicInfoSection({ form, studentId, isPwEditing, handleIsPwEditing }: Props) {
   const [opened, { open, close }] = useDisclosure();
   const [phase, setPhase] = useState<Phase>();
+  const [defaultDepartmentId, setDefaultDepartmentId] = useState<string | null>(null);
 
   useEffect(() => {
     // 학생 기본 정보 가져오기
@@ -43,6 +44,7 @@ function BasicInfoSection({ form, studentId, isPwEditing, handleIsPwEditing }: P
             phone: studentDetails.phone,
             deptId: String(studentDetails.department),
           });
+          setDefaultDepartmentId(String(studentDetails.department));
         }
       } catch (error) {
         console.error(error);
@@ -117,6 +119,7 @@ function BasicInfoSection({ form, studentId, isPwEditing, handleIsPwEditing }: P
                 },
               }}
               {...form.getInputProps("basicInfo.deptId")}
+              defaultValue={defaultDepartmentId}
             />
           </BasicRow>
         </RowGroup>


### PR DESCRIPTION
작성자: @sera2002 

Related to #{이슈 번호 기입}

## 체크 리스트

- [x] 적절한 제목으로 수정했나요?
- [ ] 상단에 이슈 번호를 기입했나요?
- [x] Target Branch를 올바르게 설정했나요?
- [x] Label을 알맞게 설정했나요?

## 작업 내역

- 관리자 페이지 중 교수 수정, 학생 수정 페이지에서 학과 정보가 default로 뜨지 않는 문제를 해결했습니다.

## 비고

- 참고 사항을 적어주세요. 코드 리뷰하는 사람이 참고해야 하는 내용을 자유로운 형식으로 적을 수 있습니다.
