### PR TITLE
[fix] 보류일 때 심사의견 undefined 표시 수정

### DIFF
--- a/src/api/_types/reviews.ts
+++ b/src/api/_types/reviews.ts
@@ -77,7 +77,7 @@ export interface FinalReviewResponse extends CommonApiResponse {
 export interface UpdateReviewRequestBody {
   contentStatus: Status;
   presentationStatus?: Status | null;
-  comment?: string;
+  comment?: string | null;
   fileUUID?: string;
 }
 

--- a/src/app/prof/review/[id]/ProfessorReviewForm.tsx
+++ b/src/app/prof/review/[id]/ProfessorReviewForm.tsx
@@ -90,6 +90,11 @@ export function ProfessorReviewForm({
         presentationStatus: input.presentation,
         ...(commentType === "심사 의견" ? { comment: input.comment } : {}),
         ...(commentType === "심사 의견 파일" ? { fileUUID } : {}),
+        ...(commentType === undefined
+          ? previous.reviewFile
+            ? { fileUUID: previous.reviewFile.uuid }
+            : { comment: previous.comment }
+          : {}),
       } satisfies UpdateReviewRequestBody,
       { baseURL: process.env.NEXT_PUBLIC_REVIEW_API_ENDPOINT }
     );
@@ -142,7 +147,12 @@ export function ProfessorReviewForm({
         review={{
           thesis: values.thesis,
           presentation: values.presentation,
-          comment: commentType === "심사 의견" ? values.comment : "",
+          comment:
+            commentType === "심사 의견"
+              ? values.comment
+              : previous.contentStatus === "PENDING"
+                ? previous.comment
+                : "",
           commentFile: commentType === "심사 의견 파일" ? values.commentFile?.name ?? null : null,
         }}
         opened={showConfirmDialog}

--- a/src/app/prof/review/[id]/ProfessorReviewForm.tsx
+++ b/src/app/prof/review/[id]/ProfessorReviewForm.tsx
@@ -153,7 +153,12 @@ export function ProfessorReviewForm({
               : previous.contentStatus === "PENDING"
                 ? previous.comment
                 : "",
-          commentFile: commentType === "심사 의견 파일" ? values.commentFile?.name ?? null : null,
+          commentFile:
+            commentType === "심사 의견 파일"
+              ? values.commentFile?.name ?? null
+              : previous.contentStatus === "PENDING"
+                ? previous.reviewFile?.name ?? null
+                : null,
         }}
         opened={showConfirmDialog}
         onConfirm={() => handleSubmit(values)}

--- a/src/components/pages/review/Review/ReviewResult.tsx
+++ b/src/components/pages/review/Review/ReviewResult.tsx
@@ -10,7 +10,7 @@ export interface ReviewResultProps {
   stage: Stage;
   thesis?: Status;
   presentation?: Status | null;
-  comment?: string;
+  comment?: string | null;
   commentFile?: string | null;
   isFinal?: boolean;
 }

--- a/src/components/pages/review/ReviewConfirmModal/ReviewConfirmModal.tsx
+++ b/src/components/pages/review/ReviewConfirmModal/ReviewConfirmModal.tsx
@@ -12,7 +12,7 @@ export interface ReviewConfirmModalProps extends PropsWithChildren {
   review: {
     thesis: Status;
     presentation: Status | null;
-    comment: string;
+    comment: string | null;
     commentFile: string | null;
   };
   opened: boolean;


### PR DESCRIPTION
작성자: @hynseok

## 체크 리스트

- [x] 적절한 제목으로 수정했나요?
- [x] 상단에 이슈 번호를 기입했나요?
- [x] Target Branch를 올바르게 설정했나요?
- [x] Label을 알맞게 설정했나요?

## 작업 내역

- 심사 결과가 보류(임시저장)일 때 -> 심사 의견 혹은 심사 의견 파일을 업로드 하지 않아도 심사를 합격 혹은 불합격으로 최종저장할 수 있음
- 이 때 심사의견 혹은 심사 의견 파일이 업로드 되지 않아 오류가 발생함
- 위 오류를 수정하였습니다.
