### PR TITLE
[FIX] 최종심사에서 심사결과를 선택해도 합격 여부 오류 메시지가 나오는 문제 해결

### DIFF
--- a/src/app/admin/results/[thesisId]/AdminReviewContent.tsx
+++ b/src/app/admin/results/[thesisId]/AdminReviewContent.tsx
@@ -165,19 +165,20 @@ function ModalContent({ open, setOpen, data, current }: ModalProps) {
             fileUUID = current.file.uuid ?? undefined;
           }
 
-          if(current.isFinal != 1) { // 최종 심사가 아닌경우, 둘 다 확인
+          if (current.isFinal !== false) {
+            // 최종 심사가 아닌경우, 둘 다 확인
             if (thesis === "UNEXAMINED" || presentation === "UNEXAMINED") {
               showNotificationError({ message: "합격 여부를 선택해주세요." });
               return;
             }
           } else {
-            if (thesis === "UNEXAMINED") { // 최종심사이면, 내용만 확인
+            if (thesis === "UNEXAMINED") {
+              // 최종심사이면, 내용만 확인
               showNotificationError({ message: "합격 여부를 선택해주세요." });
               return;
             }
           }
 
-          
           if (
             data.stage !== "REVISION" &&
             (commentType === undefined ||

--- a/src/app/admin/results/[thesisId]/AdminReviewContent.tsx
+++ b/src/app/admin/results/[thesisId]/AdminReviewContent.tsx
@@ -165,9 +165,16 @@ function ModalContent({ open, setOpen, data, current }: ModalProps) {
             fileUUID = current.file.uuid ?? undefined;
           }
 
-          if (thesis === "UNEXAMINED" || presentation === "UNEXAMINED") {
-            showNotificationError({ message: "합격 여부를 선택해주세요." });
-            return;
+          if(current.isFinal != 1) { // 최종 심사가 아닌경우, 둘 다 확인
+            if (thesis === "UNEXAMINED" || presentation === "UNEXAMINED") {
+              showNotificationError({ message: "합격 여부를 선택해주세요." });
+              return;
+            }
+          } else {
+            if (thesis === "UNEXAMINED") { // 최종심사이면, 내용만 확인
+              showNotificationError({ message: "합격 여부를 선택해주세요." });
+              return;
+            }
           }
 
           if (

--- a/src/app/admin/results/[thesisId]/AdminReviewContent.tsx
+++ b/src/app/admin/results/[thesisId]/AdminReviewContent.tsx
@@ -177,6 +177,7 @@ function ModalContent({ open, setOpen, data, current }: ModalProps) {
             }
           }
 
+          
           if (
             data.stage !== "REVISION" &&
             (commentType === undefined ||


### PR DESCRIPTION
작성자: @2tle

Related to #201 

## 체크 리스트

- [x] 적절한 제목으로 수정했나요?
- [x] 상단에 이슈 번호를 기입했나요?
- [x] Target Branch를 올바르게 설정했나요?
- [x] Label을 알맞게 설정했나요?

## 작업 내역

- 데이터베이스에서, 최종심사임에도 불구하고 구두심사결과가 `UNEXAMINED`로 설정되어 있음
- 프론트엔드에서 입력값 검사를 진행할때, 최종심사이면 내용심사결과만 확인하게 수정.
- 최종심사가 아닌경우, 내용심사 및 구두심사 결과를 모두 확인함.

## 비고

- 백엔드/DB에서 최종심사의 구두심사결과가  `UNEXAMINED`로 설정되는 원인은 엑셀 업로드시 최종심사의 구두심사결과 기본값이 UNEXAMINED로 되어있어서 발생하는 문제가 아닐까 추측됩니다.
